### PR TITLE
Add test for readability

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -42,6 +42,8 @@ function PT_do_tags(filename)
 perl <<EOF
     my $filename = VIM::Eval('a:filename');
 
+    if ( ! -r $filename ) { return; } # Unreadable file
+
     our $tagger;
     $tagger->process(files => $filename, refresh=>1 );
 


### PR DESCRIPTION
I was getting a file open error when I did something like "vim file-doesnt-yet-exist.pm" to edit a file that doesn't yet exist, probably because I was setting the filetype at vim startup.  This adds a test to avoid that problem.
