### PR TITLE
.gitmodules: use https:// to avoid ssh errors when cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "perllib/perl-tags"]
 	path = perllib/perl-tags
-	url = git@github.com:osfameron/perl-tags.git
+	url = https://github.com/osfameron/perl-tags


### PR DESCRIPTION
When using this repository with something like
junegunn/vim-plug without having setup ssh beforehand,
cloning git@github.com:foo/bar url becomes a bit
annoying.

Use the https:// url instead of git@github.com to
work more reliably in these cases.

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>